### PR TITLE
Can now bind to specific interface.

### DIFF
--- a/MultithreadedSimpleHTTPServer.py
+++ b/MultithreadedSimpleHTTPServer.py
@@ -22,14 +22,16 @@ if sys.argv[1:]:
         interface = address.split(':')[0]
         port = int(address.split(':')[1])
     else:
-        interface = ''
+        interface = '0.0.0.0'
         port = int(address)
 else:
     port = 8000
-    interface = ''
+    interface = '0.0.0.0'
 
 if sys.argv[2:]:
     os.chdir(sys.argv[2])
+
+print 'Started HTTP server on ' +  interface + ':' + str(port)
 
 server = ThreadingSimpleServer((interface, port), SimpleHTTPRequestHandler)
 try:
@@ -37,4 +39,4 @@ try:
         sys.stdout.flush()
         server.handle_request()
 except KeyboardInterrupt:
-    print("Finished")
+    print 'Finished.'

--- a/MultithreadedSimpleHTTPServer.py
+++ b/MultithreadedSimpleHTTPServer.py
@@ -17,14 +17,21 @@ import sys
 import os
 
 if sys.argv[1:]:
-    port = int(sys.argv[1])
+    address = sys.argv[1]
+    if (':' in address):
+        interface = address.split(':')[0]
+        port = int(address.split(':')[1])
+    else:
+        interface = ''
+        port = int(address)
 else:
     port = 8000
+    interface = ''
 
 if sys.argv[2:]:
     os.chdir(sys.argv[2])
 
-server = ThreadingSimpleServer(('', port), SimpleHTTPRequestHandler)
+server = ThreadingSimpleServer((interface, port), SimpleHTTPRequestHandler)
 try:
     while 1:
         sys.stdout.flush()

--- a/MultithreadedSimpleHTTPServer.py
+++ b/MultithreadedSimpleHTTPServer.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 try:
     # Python 2.x

--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ MultithreadedSimpleHTTPServer
 A Python SimpleHTTPServer-like multithreading HTTP server. Supports Python 2 & 3.
 
 ### Usage
-python MultithreadedSimpleHTTPServer.py [port] [/path/to/share]
+python MultithreadedSimpleHTTPServer.py [interface]:[port] [/path/to/share]
+####To bind to all interfaces, don't specify an interface.


### PR DESCRIPTION
Users can now bind to a specific interface by specifying an interface before the port number, separating them by a colon. 
